### PR TITLE
Fix index to point to parser module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./build/ABCParser.js');
+module.exports = require('./build/parser.js');


### PR DESCRIPTION
I got this error:
Cannot find module './build/ABCParser.js'

because there's no ABCParser.js file in build directory, but there's a parser.js .
